### PR TITLE
Fix for request map

### DIFF
--- a/model/core/Factory.php
+++ b/model/core/Factory.php
@@ -14,7 +14,6 @@
      * @param string $package
      */
     public static function boot($package) {
-        $tmpPath = sys_get_temp_dir().'/'.str_replace('/',"_",realpath($package));
 
         //boot
         try {
@@ -25,10 +24,9 @@
             throw $ex;
         }
 
-        //load the class mapping
-        $filename = $tmpPath."request-map.php";
+        $filename = RequestMapGenerator::getRequestMapFilename($package);
         if(!file_exists($filename)) {
-            RequestMapGenerator::build($package);
+            $filename = RequestMapGenerator::build($package);
         }
         include($filename);
 

--- a/model/request/RequestMapGenerator.php
+++ b/model/request/RequestMapGenerator.php
@@ -22,6 +22,7 @@ class RequestMapGenerator {
 
         //for each file in the directory
         while (($file = readdir($dh)) !== false) {
+            $string = '';
             //if it is something we want to ignore...
             if (strpos($file, '.') === 0 || $file == "test" || $file == "vendor") {
                 continue;
@@ -126,9 +127,7 @@ class RequestMapGenerator {
      */
     private static function writeRequestMap($package, $contents) {
         $contents = "<?php\n\n// controllers in: {$package}\n{$contents}";
-
-        $filename = str_replace("/", "_",realpath($package));
-        $filename = sys_get_temp_dir().DIRECTORY_SEPARATOR.$filename.".request-map.php";
+        $filename = self::getRequestMapFilename($package);
 
         try {
             file_put_contents($filename, $contents);
@@ -170,7 +169,17 @@ class RequestMapGenerator {
     public static function build($package) {
         $generator = new RequestMapGenerator();
         $contents = $generator->buildDirectory($package.'/controller/');
-        self::writeRequestMap($package, $contents);
+        return self::writeRequestMap($package, $contents);
+    }
+
+    /**
+     * @param $package
+     * @return string
+     */
+    public static function getRequestMapFilename($package)
+    {
+        $filename = str_replace("/", "_",realpath($package));
+        return sys_get_temp_dir().DIRECTORY_SEPARATOR.$filename.".request-map.php";
     }
 }
 


### PR DESCRIPTION
In previous solution there was missing dot in `$filename = $tmpPath."request-map.php";`
Plus thus path was generated in 2 different places, what is invitation for mistakes.